### PR TITLE
GP19-184: Unmocked API Request in ConferenceDetails Test

### DIFF
--- a/src/Conference/ConferenceDetails.test.js
+++ b/src/Conference/ConferenceDetails.test.js
@@ -5,6 +5,12 @@ jest.mock("react-router-dom", () => {
   };
 });
 
+jest.mock("../api", () => ({
+  getFavouritedConferencesByUserId: jest.fn(() => {
+    return [];
+  })
+}));
+
 import React from "react";
 import { Router } from "react-router-dom";
 import { ConferenceDetails } from "./ConferenceDetails";


### PR DESCRIPTION
Needs to be mocked so that running tests doesn't spit out huge amounts of error messages despite the tests passing.