### PR TITLE
GP19-181: profile page cards adjust to screen and content

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -9,7 +9,7 @@ import { logoutUser } from "./api";
 export const StyledNavbar = styled.nav`
   background: #322d38;
   width: auto;
-  height: 4vh;
+  height: 5%;
   text-align: left;
 `;
 
@@ -36,7 +36,7 @@ export const Navbar = ({ cookies, allCookies = {} }) => {
       await logoutUser(sessionToken.token);
       history.push("/");
       deleteSessionToken();
-    } catch (error) {}
+    } catch (error) { }
   };
 
   const deleteSessionToken = () => {
@@ -71,19 +71,19 @@ export const Navbar = ({ cookies, allCookies = {} }) => {
             </StyledListItem>
           </>
         ) : (
-          <>
-            <StyledListItem>
-              <StyledLink className="register" to="/users/register">
-                Register
+            <>
+              <StyledListItem>
+                <StyledLink className="register" to="/users/register">
+                  Register
               </StyledLink>
-            </StyledListItem>
-            <StyledListItem>
-              <StyledLink className="login" to="/users/login">
-                Login
+              </StyledListItem>
+              <StyledListItem>
+                <StyledLink className="login" to="/users/login">
+                  Login
               </StyledLink>
-            </StyledListItem>
-          </>
-        )}
+              </StyledListItem>
+            </>
+          )}
       </StyledList>
     </StyledNavbar>
   );

--- a/src/StyledFormComponents.js
+++ b/src/StyledFormComponents.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const StyledForm = styled.div`
-  height: 400px;
+  height: 100%;
   padding: 20px;
   display:flex; 
   flex-direction:row;
@@ -10,7 +10,7 @@ const StyledForm = styled.div`
 const StyledCardHeading = styled.h3`
   background: #dbd8db;
   width: 100%;
-  height: 55px;
+  height: 40px;
   font-size: 30px;
   font-weight: bold;
   text-align: center;
@@ -29,10 +29,10 @@ const StyledCardText = styled.h3`
 `;
 
 const StyledCard = styled.div`
-  width: ${({ profileCard }) => (profileCard ? `45%` : `900px`)};
-  height: ${({ profileCard }) => (profileCard ? `180vh` : `550px`)};
+  width: ${({ profileCard }) => (profileCard ? `65%` : `100%`)};
+  height: ${({ profileCard }) => (profileCard ? `0%` : `100%`)};
   margin: ${({ profileCard }) => (profileCard ? `10px` : `0 auto`)};
-  display: ${({ profileCard }) => profileCard && `inline-block`};
+  display: ${({ profileCard }) => (profileCard && `inline-block`)};
   border-style: solid;
   border-color: black;
   border-radius: 25px;
@@ -43,7 +43,11 @@ const StyledCard = styled.div`
   }
   vertical-align: middle;
   position: relative;
-  display: inline-block;
+  display: flex-center;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  padding-bottom: 50px;
 `;
 
 export { StyledCardHeading, StyledCardText, StyledForm, StyledCard };

--- a/src/User/ProfilePage.jsx
+++ b/src/User/ProfilePage.jsx
@@ -26,7 +26,7 @@ export const StyledEditLink = styled(Link)`
 `;
 
 const StyledProfile = styled.div`
-  height: 400px;
+  height: 100%;
   padding: 20px;
 `;
 
@@ -67,6 +67,8 @@ const ProfilePage = ({
     }
   };
 
+
+
   return (
     <StyledProfile>
       <StyledCard profileCard>
@@ -84,7 +86,21 @@ const ProfilePage = ({
         {isCurrentUser && displayManager()}
       </StyledCard>
       {isCurrentUser && (
-        <>
+        <> <StyledCard profileCard className="employeesCard">
+          {employees.length > 0 ? (
+            <>
+              <StyledCardHeading className="employeeListHeader">
+                Employees:
+                </StyledCardHeading>
+              <EmployeeList className="employeeList" employees={employees} />
+            </>
+          ) : (
+              <StyledCardHeading className="employeeListHeader">
+                No Linked Employees
+              </StyledCardHeading>
+            )}
+        </StyledCard>
+
           <StyledCard profileCard>
             {favouriteConferences.length > 0 ? (
               <>
@@ -97,24 +113,10 @@ const ProfilePage = ({
                 />
               </>
             ) : (
-              <StyledCardHeading className="favouriteConferencesHeader">
-                No Favourited Conferences
+                <StyledCardHeading className="favouriteConferencesHeader">
+                  No Favourited Conferences
               </StyledCardHeading>
-            )}
-          </StyledCard>
-          <StyledCard className="employeesCard">
-            {employees.length > 0 ? (
-              <>
-                <StyledCardHeading className="employeeListHeader">
-                  Employees:
-                </StyledCardHeading>
-                <EmployeeList className="employeeList" employees={employees} />
-              </>
-            ) : (
-              <StyledCardHeading className="employeeListHeader">
-                No Linked Employees
-              </StyledCardHeading>
-            )}
+              )}
           </StyledCard>
         </>
       )}


### PR DESCRIPTION
<img width="990" alt="Screenshot 2020-01-09 at 16 40 53" src="https://user-images.githubusercontent.com/54947794/72086834-80f7e380-32ff-11ea-8916-97e5e3d96803.png">
<img width="478" alt="Screenshot 2020-01-09 at 16 43 42" src="https://user-images.githubusercontent.com/54947794/72086836-80f7e380-32ff-11ea-9645-f1f4224d182e.png">

I have changed the CSS so the profile page cards adjust to the content they contain and to the screen size